### PR TITLE
Fix some typos in Chapter1

### DIFF
--- a/Chapter_1/1.1.md
+++ b/Chapter_1/1.1.md
@@ -151,10 +151,10 @@ ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin13]
 ```
 rvm gemset create rails4.2
 rvm use 2.2.0@rails4.2 --default
-gem install rails -v 4.2.0 --no-ri --no-rdoc
+gem install rails -v 4.2.0 --no-document
 ```
 
-注：`--no-ri --no-rdoc` 会跳过安装 ri 和 rdoc 文档，可以减少安装时间。
+注：`--no-document` 会跳过安装 ri 和 rdoc 文档，可以减少安装时间。
 
 注：在一些系统环境中，还需要先安装 bundler，它的命令是 `gem install bundler`。Bundler 是Ruby 跟踪和安装 Gem 的工具，它的官网在这里 [http://bundler.io/](http://bundler.io/)。
 

--- a/Chapter_1/1.2.md
+++ b/Chapter_1/1.2.md
@@ -37,7 +37,7 @@ rails _4.1.5_ new shop
 
 #### config 文件夹
 
-这里存放的是 Rails 的配置文件。首先，打开 environments 文件夹，我们可以看到三个文件，这分别对应 Rails 的三种运行环境，我们开始时候使用的是 development 环境，运行测试时是 test 环境，当我们把代码部署到服务器上，正式上线的时候，使用的是 production 环境。 
+这里存放的是 Rails 的配置文件。首先，打开 environments 文件夹，我们可以看到三个文件，这分别对应 Rails 的三种运行环境，我们开始时候使用的是 development 环境，运行测试时是 test 环境，当我们把代码部署到服务器上，正式上线的时候，使用的是 production 环境。
 
 Rails 允许我们分别为三种环境做不同的设置，比如，production 中 `config.assets.digest = true`，而开发环境可以设为 `config.assets.digest = false`。
 
@@ -55,7 +55,7 @@ secrets.yml 中的配置分别对应三种运行环境，它是用来加密我�
 
 migrate 文件夹中，存放的是我们的数据库迁移文件，下一章我们会经常看到它。
 
-这里还有一个 seed.rb 文件，可以用它来为项目创建一些初始数据。
+这里还有一个 seeds.rb 文件，可以用它来为项目创建一些初始数据。
 
 #### lib 文件夹
 
@@ -169,6 +169,3 @@ rake routes
 它会列出我们所有定义的路由（routes）列表。
 
 你也可以自己编写一个 Rake 任务，放到 lib/tasks/中，扩展名为 .rake。
-
-
-


### PR DESCRIPTION
1. use `--no-document` instead of `--no-ri --no-rdoc`
   As per the official [RubyGems guides](http://guides.rubygems.org/command-reference/#gem-install), `--no-ri --no-rdoc` options are deprecated, `--no-document` is preferred. 
2. Fix typo in 1.2.md
   In Rails 4.2, `seed.rb` was renamed to `seeds.rb`.
